### PR TITLE
[feature]add insert update on duplicate key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '6'
+  - '8'
 sudo: false
 script:
     - "npm test"

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -23,6 +23,8 @@ module.exports = class MysqlParser extends Parser {
    */
   escapeString(str) {
     if (!str) return '';
+
+    // eslint-disable-next-line no-control-regex
     return str.replace(/[\0\n\r\b\t\\'"\x1a]/g, s => {
       switch (s) {
         case '\0':

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,5 +1,5 @@
 const helper = require('think-helper');
-const {Parser} = require('think-model-abstract');
+const { Parser } = require('think-model-abstract');
 
 module.exports = class MysqlParser extends Parser {
   /**
@@ -41,5 +41,40 @@ module.exports = class MysqlParser extends Parser {
           return '\\' + s;
       }
     });
+  }
+
+  /**
+   * get insert sql
+   * @param {Object} options
+   */
+  buildInsertSql(options, replace) {
+    const isUpdate = helper.isObject(options.update) || helper.isArray(options.update);
+    if (replace || !isUpdate) {
+      return super.buildInsertSql(options, replace);
+    }
+
+    const table = this.parseTable(options.table);
+    const values = options.values[0] !== '(' ? `(${options.values})` : options.values;
+
+    let sets = [];
+    if (helper.isArray(options.update)) {
+      sets = options.update.map(field => {
+        field = this.parseKey(field);
+        return field + '=' + `VALUES(${field})`;
+      });
+    } else {
+      for (const key in options.update) {
+        const value = this.parseValue(options.update[key]);
+        if (helper.isString(value) || helper.isNumber(value) || helper.isBoolean(value)) {
+          sets.push(this.parseKey(key) + '=' + value);
+        }
+      }
+    }
+
+    const duplicateUpdate = sets.length ? ' ON DUPLICATE KEY UPDATE ' + sets.join(',') : '';
+    const lock = this.parseLock(options.lock);
+    const comment = this.parseComment(options.comment);
+
+    return `INSERT INTO ${table} (${options.fields}) VALUES ${values}${duplicateUpdate}${lock}${comment}`;
   }
 };

--- a/package.json
+++ b/package.json
@@ -37,16 +37,5 @@
     "eslint-config-think": "^1.0.1",
     "muk": "^0.5.3",
     "nyc": "^10.3.0"
-  },
-  "ava": {
-    "require": [
-      "babel-register"
-    ],
-    "babel": "inherit"
-  },
-  "babel": {
-    "presets": [
-      "think-node"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
   },
   "homepage": "https://github.com/thinkjs/think-model-mysql#readme",
   "dependencies": {
-    "think-debounce": "^1.0.3",
-    "think-helper": "^1.0.5",
-    "think-model-abstract": "^1.0.5",
-    "think-mysql": "^1.0.2"
+    "think-debounce": "^1.0.4",
+    "think-helper": "^1.1.2",
+    "think-model-abstract": "^1.2.2",
+    "think-mysql": "^1.2.4"
   },
   "devDependencies": {
     "ava": "^0.19.1",
-    "eslint": "^4.2.0",
+    "eslint": "^4.19.1",
     "eslint-config-think": "^1.0.1",
     "muk": "^0.5.3",
     "nyc": "^10.3.0"


### PR DESCRIPTION
MySQL support update when insert data return duplicate key error. There has three types to use it:

```js
const userModel = new Model('user', {...});
const insertData = {id: 3, user: 'lizheming', mail: 'i@imnerd.org'};

(async() => {
  // update all insertData fields when meets duplicate keys
  // this feature should require with think-model-abstract with this pull request 
  // https://github.com/thinkjs/think-model-abstract/pull/6
  await userModel.add(insertData, {update: true});
  
  // just update user and mail fields when meets duplicate keys
  await userModel.add(insertData, {update: ['user', 'mail']});

  // update user and mail with defined value when meets duplicate keys
  await userModel.add(insertData: {update: {user: 'exist-lizheming', mail: ['EXP', 'VALUES(mail)']}});
})();
```
Read more about `INSERT ... ON DUPLICATE KEY UPDATE` https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html