### PR TITLE
[feat] stringify data when column type is json

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -6,7 +6,7 @@ const Mysql = require('think-mysql');
  */
 module.exports = class MysqlQuery extends Query {
   select(options, cache) {
-    if(!this.config.jsonFormat) {
+    if (!this.config.jsonFormat) {
       return super.select(options, cache);
     }
 
@@ -23,7 +23,7 @@ module.exports = class MysqlQuery extends Query {
       return data;
     });
   }
-  
+
   /**
    * get socket
    * @param {String|Object} sql

--- a/lib/query.js
+++ b/lib/query.js
@@ -5,6 +5,25 @@ const Mysql = require('think-mysql');
  * mysql query
  */
 module.exports = class MysqlQuery extends Query {
+  select(options, cache) {
+    if(!this.config.jsonFormat) {
+      return super.select(options, cache);
+    }
+
+    return Promise.all([
+      super.select(options, cache),
+      this.schema.getSchema()
+    ]).then(([data, schema]) => {
+      const keys = Object.keys(schema).filter(key => schema[key].tinyType === 'json');
+      (Array.isArray(data) ? data : [data]).forEach(row => {
+        keys.filter(key => row[key] !== undefined).forEach(key => {
+          row[key] = JSON.parse(row[key]);
+        });
+      });
+      return data;
+    });
+  }
+  
   /**
    * get socket
    * @param {String|Object} sql

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -88,6 +88,9 @@ module.exports = class MysqlSchema extends Schema {
     if (tinyType.indexOf('int') > -1) return parseInt(value, 10) || 0;
     if (['double', 'float', 'decimal'].indexOf(tinyType) > -1) return parseFloat(value, 10) || 0;
     if (tinyType === 'bool') return value ? 1 : 0;
+    if (this.config.jsonFormat && tinyType === 'json') {
+      return JSON.stringify(value);
+    }
     return value;
   }
 };

--- a/test/lib/query.js
+++ b/test/lib/query.js
@@ -3,6 +3,50 @@ const helper = require('think-helper');
 const Base = require('../../lib/query');
 const Parser = require('../../lib/parser');
 
+ava.test('select jsonFormat false', t => {
+  t.plan(2);
+
+  const instance = new Base();
+  instance.__proto__.__proto__.select = function(options, cache) {
+    t.is(options, 1);
+    t.is(cache, 2);
+  }
+  instance.select(1, 2);
+})
+
+ava.test('select jsonFormat true', async t => {
+  t.plan(2);
+  
+  const instance = new Base({jsonFormat: true});
+  instance.schema = {
+    getSchema() {
+      return {
+        title: {
+          tinyType: 'varchar'
+        },
+        content: {
+          tinyType: 'varchar'
+        },
+        json: {
+          tinyType: 'json'
+        }
+      };
+    }
+  }
+  instance.__proto__.__proto__.select = function() {
+    return {title: 'hello', content: 'world', json: JSON.stringify([1,2,3,4])};
+  }
+  const data = await instance.select();
+  t.deepEqual(data, {title: 'hello', content: 'world', json: [1,2,3,4]});
+
+
+  instance.__proto__.__proto__.select = function() {
+    return [{title: 'hello', content: 'world', json: JSON.stringify([1,2,3,4])}];
+  }
+  const data2 = await instance.select();
+  t.deepEqual(data2, [{title: 'hello', content: 'world', json: [1,2,3,4]}]);
+});
+
 ava.test('socket is function', t => {
   const instance = new Base();
   t.true(helper.isFunction(instance.socket));

--- a/test/lib/schema.js
+++ b/test/lib/schema.js
@@ -379,7 +379,9 @@ test('schema get normal schema 4', async t => {
 });
 
 test('schema parse type', t => {
-  const schema = new Schema({});
+  t.plan(13);
+  
+  const schema = new Schema({jsonFormat: true});
   t.is(schema.parseType('enum', '1'), '1');
   t.is(schema.parseType('set', 'True'), 'True');
   t.is(schema.parseType('bigint', 'False'), 'False');
@@ -392,4 +394,5 @@ test('schema parse type', t => {
   t.is(schema.parseType('bool', '0'), 1);
   t.is(schema.parseType('bool', ''), 0);
   t.is(schema.parseType('xxx', 'aaa'), 'aaa');
+  t.is(schema.parseType('json', [1,2,3,4]), '[1,2,3,4]');
 });


### PR DESCRIPTION
It can make think-model module output JSON data when column type is json, that's better than before. close thinkjs/thinkjs#1511 when pr merged.

- [x] add JSON.parse when find() and select()
- [x] add JSON.stringify when add() and update()
