### PR TITLE
fix type bigint unsigned

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -84,7 +84,7 @@ module.exports = class MysqlSchema extends Schema {
    * @param {Mixed} value
    */
   parseType(tinyType, value) {
-    if (tinyType === 'enum' || tinyType === 'set' || tinyType === 'bigint') return value;
+    if (tinyType === 'enum' || tinyType === 'set' || tinyType === 'bigint' || tinyType === 'bigint unsigned') return value;
     if (tinyType.indexOf('int') > -1) return parseInt(value, 10) || 0;
     if (['double', 'float', 'decimal'].indexOf(tinyType) > -1) return parseFloat(value, 10) || 0;
     if (tinyType === 'bool') return value ? 1 : 0;


### PR DESCRIPTION
This is to fix the problem of precision loss of MySQL submitted field type.
At the same time, I also noticed that MySQL bigint or bigint unsigned type can be submitted by string. Therefore, nodejs can submit the above two types to avoid the problem of precision loss by submitting string. Similarly, as long as the return type is string, the corresponding problem can be solved (the new version is said to support it). I'm just talking about it here, so as to locate and deal with the old and new problems.